### PR TITLE
Auto Creates the destination Directory

### DIFF
--- a/SessionDownloader/SessionDownloader.cs
+++ b/SessionDownloader/SessionDownloader.cs
@@ -170,6 +170,9 @@ namespace SessionDownloader
 
         private void Initialize()
         {
+            if (!Directory.Exists(this.DestinationRootPath))
+                Directory.CreateDirectory(this.DestinationRootPath);
+
             this._sessionInfoList = new List<SessionInfo>();
 
             SetFeedUri();


### PR DESCRIPTION
Currently, if the destination directory specified doesn't exist the SessionDownloader will crash, throwing a System.IO.DirectoryNotFoundException.

These changes will automatically create the destination folder if it doesn't exist to resolve this issue.
